### PR TITLE
avoid warnings from Bluebird when in "debug" mode

### DIFF
--- a/src/fsm.js
+++ b/src/fsm.js
@@ -64,6 +64,10 @@ function StateMachine(configuration, target) {
     }
   });
 
+  function identity(param) {
+    return param;
+  }
+  
   function addEvent(event) {
     events[event.name] = events[event.name] || {};
 
@@ -135,15 +139,15 @@ function StateMachine(configuration, target) {
       return promise
       .then(isValidEvent)
       .then(canTransition)
-      .then(callbacks['onleave' + current] ? callbacks['onleave' + current].bind(target, options) : undefined)
-      .then(callbacks['onleave'] ? callbacks['onleave'].bind(target, options) : undefined)
+      .then(callbacks['onleave' + current] ? callbacks['onleave' + current].bind(target, options) : identity)
+      .then(callbacks['onleave'] ? callbacks['onleave'].bind(target, options) : identity)
       .then(onleavestate.bind(target, options))
-      .then(callbacks['on' + name] ? callbacks['on' + name].bind(target, options) : undefined)
-      .then(callbacks['onenter' + events[name][current]] ? callbacks['onenter' + events[name][current]].bind(target, options) : undefined)
-      .then(callbacks['onenter'] ? callbacks['onenter'].bind(target, options) : undefined)
+      .then(callbacks['on' + name] ? callbacks['on' + name].bind(target, options) : identity)
+      .then(callbacks['onenter' + events[name][current]] ? callbacks['onenter' + events[name][current]].bind(target, options) : identity)
+      .then(callbacks['onenter'] ? callbacks['onenter'].bind(target, options) : identity)
       .then(onenterstate.bind(target, options))
-      .then(callbacks['onentered' + events[name][current]] ? callbacks['onentered' + events[name][current]].bind(target, options) : undefined)
-      .then(callbacks['onentered'] ? callbacks['onentered'].bind(target, options) : undefined)
+      .then(callbacks['onentered' + events[name][current]] ? callbacks['onentered' + events[name][current]].bind(target, options) : identity)
+      .then(callbacks['onentered'] ? callbacks['onentered'].bind(target, options) : identity)
       .catch(revert);
     };
   }


### PR DESCRIPTION
- if resolving a promise with bluebird's `settled()`, "debug" mode is enabled
- if "debug" mode is enabled, and `then()` is not passed a function (instead, `undefined`), bluebird emits a warning:

  ```
  Warning: .then() only accepts functions but was passed: [object Undefined]
  ```
- instead of passing `undefined` to `then()`, use an identity function.