### PR TITLE
allow conditional transition by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,14 +432,30 @@ StateMachine({
       from: 'init',
       to: ['one', 'two'],
       condition: function (options) {
-        return indexInToStates;
+        return 0; // transition to state 'one'
       }
     }
   ]
 });
 ```
 
-The condition callback must return an index of the selected state or a promise that resolves to the index. The condition callback is executed after `on{eventName}` callback.
+The above is equivalent to:
+
+```javascript
+StateMachine({
+  events: [
+    { name: 'conditional',
+      from: 'init',
+      to: ['one', 'two'],
+      condition: function (options) {
+        return 'one'; // transition to state 'one'
+      }
+    }
+  ]
+});
+```
+
+The condition callback must return the `to` Array's index of the selected state, the name of the selected state, or a promise which resolves to either.  The condition callback is executed after `on{eventName}` callback.
 
 If the above is not suitable, complex conditional transitions can be achieved through transitioning explicitly to a pseuso state where the condition is checked, then the apropriate event is triggered:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,13 @@ function StateMachine(configuration, target) {
         return new Promise(function (resolve) {
           resolve(event.condition(options));
         }).then(function (index) {
-          var toState = event.to[index];
+          var toState;
+
+          if (typeof index === 'number') {
+            toState = event.to[index];
+          } else if (event.to.indexOf(index) > -1) {
+            toState = index;
+          }
 
           if (toState === undefined) {
             return target[pseudoEvent(pseudoState, noChoiceFound)]().then(function () {

--- a/test/specs/conditional-transition.js
+++ b/test/specs/conditional-transition.js
@@ -21,38 +21,76 @@ module.exports = function (promise) {
       
       done();
     });
-    
-    it('should transition to first choice', function (done) {
-      var fsm = StateMachine({
-        initial: 'init',
-        events: [
-          { name: 'start', from: 'init', to: ['a', 'b'], condition: function (options) {
-            return 0;
-          } }
-        ]
+
+    describe('when the condition callback returns a numeric index', function() {
+      it('should transition to first choice', function (done) {
+        var fsm = StateMachine({
+          initial: 'init',
+          events: [
+            { name: 'start', from: 'init', to: ['a', 'b'], condition: function (options) {
+              return 0;
+            } }
+          ]
+        });
+
+        fsm.start().then(function () {
+          expect(fsm.current).to.be.equal('a');
+
+          done();
+        });
       });
-      
-      fsm.start().then(function () {
-        expect(fsm.current).to.be.equal('a');
-      
-        done();
+
+      it('should transition to second choice', function (done) {
+        var fsm = StateMachine({
+          initial: 'init',
+          events: [
+            { name: 'start', from: 'init', to: ['a', 'b'], condition: function (options) {
+              return 1;
+            } }
+          ]
+        });
+
+        fsm.start().then(function () {
+          expect(fsm.current).to.be.equal('b');
+
+          done();
+        });
       });
     });
 
-    it('should transition to second choice', function (done) {
-      var fsm = StateMachine({
-        initial: 'init',
-        events: [
-          { name: 'start', from: 'init', to: ['a', 'b'], condition: function (options) {
-            return 1;
-          } }
-        ]
+    describe('when the condition callback returns a state name', function() {
+      it('should transition to first choice', function (done) {
+        var fsm = StateMachine({
+          initial: 'init',
+          events: [
+            { name: 'start', from: 'init', to: ['a', 'b'], condition: function (options) {
+              return 'a';
+            } }
+          ]
+        });
+
+        fsm.start().then(function () {
+          expect(fsm.current).to.be.equal('a');
+
+          done();
+        });
       });
-      
-      fsm.start().then(function () {
-        expect(fsm.current).to.be.equal('b');
-      
-        done();
+
+      it('should transition to second choice', function (done) {
+        var fsm = StateMachine({
+          initial: 'init',
+          events: [
+            { name: 'start', from: 'init', to: ['a', 'b'], condition: function (options) {
+              return 'b';
+            } }
+          ]
+        });
+
+        fsm.start().then(function () {
+          expect(fsm.current).to.be.equal('b');
+
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
- added a couple tests to convince myself it works; slight reorganization here
- updated `README.md` to make a bit more clear in either case

* * *

I thought it was a little awkward to have to return a numeric index from the `conditional` callback, so that's what prompted this.  Does not break backwards compatibility.