### PR TITLE
add note about async pseudo-states

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ StateMachine({
 });
 ```
 
+If your pseudo state's callback returns a Promise, you must return the call to the event function; e.g. `return this.triggerOptionA()`.
+
 ## UML visualization
 
 The state machine definitions can be visualized as UML diagrams using [fsm2dot](https://github.com/vstirbu/fsm2dot).


### PR DESCRIPTION
I noticed the example given for using a custom "pseudo" state didn't work with async callbacks, so this adds a note about it.