### PR TITLE
allow "instance"-style usage

### DIFF
--- a/lib/event-emittable.js
+++ b/lib/event-emittable.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var stampit = require('stampit');
+var EventEmitter = require('events').EventEmitter;
+var _ = require('lodash');
+
+var EventEmittable = stampit.convertConstructor(EventEmitter)
+  .static({
+    /**
+     * This is a hack around EventEmitter's own static init() function in
+     * some newer node versions.
+     * @returns {Object}
+     */
+    init: function init() {
+      return this.enclose.apply(this, arguments);
+    },
+    /**
+     * Mixes an EventEmittable into an existing object.
+     * @param {Object} obj Any object
+     * @returns {Object} The same object with new EventEmittable powers
+     */
+    assign: function assign (obj) {
+      _.assign(obj, this.fixed.methods);
+      return _.first(this.fixed.init)({instance: obj});
+    }
+  });
+
+module.exports = EventEmittable;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@
 var FsmError = require('./fsm-error');
 var stampit = require('stampit');
 var _ = require('lodash');
-var EventEmitter = require('events').EventEmitter;
+var EventEmittable = require('./event-emittable');
 
 var StateMachine = stampit({
   props: {
@@ -26,8 +26,6 @@ var StateMachine = stampit({
     current: 'none'
   },
   static: {
-    Promise: global.Promise || require('es6-promise').Promise,
-    FsmError: FsmError,
     noChoiceFound: 'no-choice',
     type: function type (options) {
       var Type = this.Type;
@@ -51,21 +49,23 @@ var StateMachine = stampit({
     }
   },
   methods: {
-    emit: _.noop,
+    emit: function emit () {
+      return this.target.emit.apply(this.target, arguments);
+    },
     canTransition: function canTransition (options) {
       var factory = this.factory;
       var Type = factory.Type;
       switch (factory.type(options)) {
         case Type.NOOP:
           if (this.inTransition) {
-            throw new factory.FsmError('Previous transition pending', options);
+            throw new this.FsmError('Previous transition pending', options);
           }
           break;
         case Type.INTER:
           if (this.states[this.current].noopTransition >
             0 ||
             this.inTransition) {
-            throw new factory.FsmError('Previous transition pending', options);
+            throw new this.FsmError('Previous transition pending', options);
           }
           break;
         default:
@@ -94,7 +94,7 @@ var StateMachine = stampit({
     },
     isValidEvent: function isValidEvent (options) {
       if (this.cannot(options.name)) {
-        throw new this.factory.FsmError('Invalid event in current state', options);
+        throw new this.FsmError('Invalid event in current state', options);
       }
 
       return options;
@@ -115,7 +115,7 @@ var StateMachine = stampit({
     },
     addBasicEvent: function addBasicEvent (event) {
       if (_.isArray(event.to)) {
-        throw new this.factory.FsmError('Ambigous transition', event);
+        throw new this.FsmError('Ambigous transition', event);
       }
 
       event.from = [].concat(event.from || []);
@@ -129,7 +129,7 @@ var StateMachine = stampit({
       var factory = this.factory;
       var noChoiceFound = factory.noChoiceFound;
       var pseudoEvent = factory.pseudoEvent;
-      var Promise = factory.Promise;
+      var Promise = this.Promise;
 
       if (_.isArray(event.from)) {
         return _.forEach(event.from, function (from) {
@@ -193,8 +193,8 @@ var StateMachine = stampit({
             if (_.isUndefined(toState)) {
               return target[pseudoEvent(pseudoState, noChoiceFound)]()
                 .then(function () {
-                  throw new factory.FsmError('Choice index out of range', event);
-                });
+                  throw new this.FsmError('Choice index out of range', event);
+                }.bind(this));
             } else {
               return target[pseudoEvent(pseudoState, toState)].apply(target,
                 options.args);
@@ -282,7 +282,7 @@ var StateMachine = stampit({
           pOptions = this.preprocessPseudoEvent(name, options);
         }
 
-        return new this.factory.Promise(function (resolve) {
+        return new this.Promise(function (resolve) {
           resolve(options);
         })
           .then(this.isValidEvent.bind(this))
@@ -357,48 +357,19 @@ var StateMachine = stampit({
           throw err;
         }
       }.bind(this);
-    },
-    initTarget: function initTarget(target) {
-      var mixin;
-
-      if (!_.isObject(target)) {
-        target = new EventEmitter();
-      }
-
-      if (_.isFunction(target.emit)) {
-        this.emit = function emit () {
-          return target.emit.apply(target, arguments);
-        };
-      }
-
-      mixin = _.mapValues(this.events, function (event, name) {
-        return this.buildEvent(name);
-      }, this);
-
-      _.assign(target, mixin, {
-        can: this.can.bind(this),
-        cannot: this.cannot.bind(this),
-        is: this.is.bind(this),
-        hasState: this.hasState.bind(this),
-        isFinal: this.isFinal.bind(this)
-      });
-
-      Object.defineProperty(target, 'current', {
-        get: function getCurrent () {
-          return this.current;
-        }.bind(this)
-      });
-
-      this.target = target;
-
-      return target;
     }
   },
   init: function init (context) {
-    this.factory = context.stamp;
-
     var events = this.events;
+
+    var target = this.target = this.target || EventEmittable();
+    if (!_.isFunction(target.emit)) {
+      EventEmittable.assign(target);
+    }
+    
+    this.factory = context.stamp;
     this.events = {};
+
     _.forEach(events, function (event, name) {
       if (_.isString(name)) {
         event.name = name;
@@ -411,9 +382,68 @@ var StateMachine = stampit({
       this.addState(event.to);
     }, this);
 
+    this.mixin = _(this.events)
+      .mapValues(function (event, name) {
+        return this.buildEvent(name);
+      }, this)
+      .assign({
+        can: this.can.bind(this),
+        cannot: this.cannot.bind(this),
+        is: this.is.bind(this),
+        hasState: this.hasState.bind(this),
+        isFinal: this.isFinal.bind(this)
+      })
+      .value();
+
     this.current = this.initial;
-    return this.initTarget(_.first(context.args));
   }
 });
 
-module.exports = StateMachine;
+var Target = stampit({
+  props: {
+    events: {},
+    callbacks: {},
+    initial: 'none',
+    final: null
+  },
+  static: {
+    StateMachine: StateMachine,
+    Promise: global.Promise || require('es6-promise').Promise,
+    FsmError: FsmError
+  },
+  init: function init (context) {
+    var target = _.first(context.args) || this;
+
+    _.defaults(target, {
+      events: this.events,
+      callbacks: this.callbacks,
+      initial: this.initial,
+      final: this.final
+    }, {
+      events: {},
+      callbacks: {},
+      initial: 'none',
+      final: null
+    });
+
+    var stateMachine = context.stamp.StateMachine({
+      target: target,
+      events: target.events,
+      callbacks: target.callbacks,
+      initial: target.initial,
+      final: target.final,
+      Promise: context.stamp.Promise,
+      FsmError: context.stamp.FsmError
+    });
+
+    Object.defineProperty(target, 'current', {
+      get: function getCurrent () {
+        return stateMachine.current;
+      }
+    });
+
+    return _.assign(target, stateMachine.mixin);
+  }
+}).compose(EventEmittable);
+
+module.exports = Target;


### PR DESCRIPTION
This needs tests, obviously, but it brings fsm-as-promised more inline with how these composable factories are intended to be used.  PR #15 was simply a refactor; almost no actual API changes were involved.

Whenever you call a "stamp" (a composable factory function) created by Stampit, the first parameter is always going to be an object.  The object returned is, by default, *not* the object you pass as the parameter.  However, the object you pass (henceforth known as an "instance") is *mixed in* (via `Object.assign()`, `_.assign()`, etc) to the resulting object, e.g.:

```js
const MyStamp = stampit({
  methods: {
    foo () {
      return this.bar;
    }
  }
});

const myObj = MyStamp({bar: 'baz'});
myObj.foo() // baz
```

fsm-as-promised's API allows mixing in of an instance via the *second* parameter; the first, of course, being simply the configuration.

With these changes, we can now compose freely with `fsm-as-promised`.  Before this change, the following would not work as expected:

```js
const myObj = StateMachine({
  foo: 'bar',
  events: {}, 
  callbacks: {}, 
  initial: 'start'});

myObj.foo // undefined
```

Above, the first parameter is used for configuration, then thrown away.  To get this behavior, you'd need to do:

```js
const myObj = StateMachine({
  events: {}, 
  callbacks: {}, 
  initial: 'start'}, 
  {
    foo: 'bar'
  });

myObj.foo // 'bar'
```

Now, the above is *still supported*, but the problem with this is that if you ever wanted to compose *from* `StateMachine`, you're in for pain, because *the first parameter is thrown away*.

```js
const MyStamp = stampit({
  methods: {
    foo () {
      return this.bar;
    }
  }
}).compose(StateMachine);

const myObj = MyStamp({
  events: {}, 
  callbacks: {}, 
  initial: 'start'
});

myObj.foo() // TypeError: myObj.foo is not a function
```

Oops.  Anyway, the old behavior *is still supported* with some trickery--and it will now "mix in" an EventEmitter into the second parameter (`target`) if it has no `emit` function--but now this works as expected:

```js
const myObj = StateMachine({
  foo: 'bar',
  events: {}, 
  callbacks: {}, 
  initial: 'start'});

myObj.foo // 'bar'
```

This is accomplished by providing a second factory function (`Target`) which creates an instance of `StateMachine` internally, which sets everything up.  `StateMachine` then exposes a `mixin` object for the `Target` to mix into itself via `_.assign()`.

Of note, when you write:

```js
var StateMachine = require('fsm-as-promised');
```

you are now no longer using the `StateMachine` factory; you're actually getting `Target`.  For hacking's sake, to get the *actual* `StateMachine` factory, you'd do this:

```js
var StateMachine = require('fsm-as-promised').StateMachine;
```

This change should be transparent to the user, unless they are vehemently opposed to having an `EventEmitter` mixed in to their target object (second parameter, as per the old API).

`EventEmittable` is a composable factory function (a "stamp") wrapping `EventEmitter`.  To use it, simply call `.compose(EventEmittable)` upon any stamp.