### PR TITLE
Add generic error handler that can potentially be overriden by librar…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,20 +59,23 @@ var StateMachine = stampit({
   },
   methods: {
     emit: _.noop,
+    error: function(msg, option) {
+      throw new this.factory.FsmError(msg, option);
+    },
     canTransition: function canTransition (options) {
       var factory = this.factory;
       var Type = factory.Type;
       switch (factory.type(options)) {
         case Type.NOOP:
           if (this.inTransition) {
-            throw new factory.FsmError('Previous transition pending', options);
+            this.error('Previous transition pending', options);
           }
           break;
         case Type.INTER:
           if (this.states[this.current].noopTransition >
             0 ||
             this.inTransition) {
-            throw new factory.FsmError('Previous transition pending', options);
+            this.error('Previous transition pending', options);
           }
           break;
         default:
@@ -101,7 +104,7 @@ var StateMachine = stampit({
     },
     isValidEvent: function isValidEvent (options) {
       if (this.cannot(options.name)) {
-        throw new this.factory.FsmError('Invalid event in current state', options);
+        this.error('Invalid event in current state', options);
       }
 
       return options;
@@ -122,7 +125,7 @@ var StateMachine = stampit({
     },
     addBasicEvent: function addBasicEvent (event) {
       if (_.isArray(event.to)) {
-        throw new this.factory.FsmError('Ambigous transition', event);
+        this.error('Ambigous transition', event);
       }
 
       event.from = [].concat(event.from || []);
@@ -181,7 +184,6 @@ var StateMachine = stampit({
 
       this.callbacks[callbackPrefix + 'entered' + pseudoState] = function (options) {
         var target = this.target;
-
         _.defaults(options, {
           args: []
         });
@@ -197,12 +199,9 @@ var StateMachine = stampit({
             } else if (_.includes(event.to, index)) {
               toState = index;
             }
-
             if (_.isUndefined(toState)) {
               return target[pseudoEvent(pseudoState, noChoiceFound)]()
-                .then(function () {
-                  throw new factory.FsmError('Choice index out of range', event);
-                });
+                .then(this.error.bind(this, 'Choice index out of range', event));
             } else {
               return target[pseudoEvent(pseudoState, toState)].apply(target,
                 options.args);


### PR DESCRIPTION
This PR is a suggestion to deal with #14. With it users of the library can provide their own error handling logic by overriding the error function.

In our case this PR allowed us to define a custom handler when you throw Exceptions like "Invalid event in current state", and then we can translate that Exception to one of our own. Thus we define this in a central place instead of needing to catch every time we call any event, and do the proper translation.

What do you think?




