### PR TITLE
Bind the condition function to 'target' as all other callback handlers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -189,7 +189,7 @@ var StateMachine = stampit({
         });
 
         return new Promise(function (resolve) {
-          resolve(event.condition(options));
+          resolve(event.condition.call(target, options));
         })
           .then(function (index) {
             var toState;

--- a/test/specs/basic.js
+++ b/test/specs/basic.js
@@ -1,4 +1,5 @@
 /*jshint -W030 */
+var sinon = require('sinon');
 module.exports = function (promise) {
   describe('Basic operations', function () {
 
@@ -309,6 +310,25 @@ module.exports = function (promise) {
       fsm.walk().then(function () {
         expect(called).to.be.deep.equal(['leavehere', 'leave', 'walk', 'enterhere', 'enter', 'enteredhere','entered']);
 
+        done();
+      });
+    });
+
+    it('should call callbacks with the value of "this" set to the state machine', function (done) {
+      StateMachine.Promise = promise;
+      const onWarnSpy = sinon.spy();
+      var fsm = StateMachine({
+        initial: 'green',
+        events: [
+          { name: 'warn',  from: 'green',  to: 'yellow' }
+        ],
+        callbacks: {
+          onwarn: onWarnSpy,
+        }
+      });
+
+      fsm.warn().then(function () {
+        expect(onWarnSpy.thisValues[0]).to.eql(fsm);
         done();
       });
     });

--- a/test/specs/conditional-transition.js
+++ b/test/specs/conditional-transition.js
@@ -1,5 +1,6 @@
 /* global expect */
 /* global StateMachine */
+var sinon = require('sinon');
 module.exports = function (promise) {
   StateMachine.Promise = promise;
 
@@ -12,13 +13,13 @@ module.exports = function (promise) {
           { name: 'start', from: 'init', to: ['a', 'b'], condition: function () {} }
         ]
       });
-      
+
       expect(fsm.current).to.be.equal('init');
       expect(fsm.hasState('init__start')).to.be.true;
       expect(fsm).to.have.ownProperty('init__start--a');
       expect(fsm).to.have.ownProperty('init__start--b');
       expect(fsm).to.have.ownProperty('init__start--no-choice');
-      
+
       done();
     });
 
@@ -102,19 +103,19 @@ module.exports = function (promise) {
             var promise = new StateMachine.Promise(function (resolve, reject) {
               resolve(0);
             });
-            
+
             return promise;
           } }
         ]
       });
-      
+
       fsm.start().then(function () {
         expect(fsm.current).to.be.equal('a');
-      
+
         done();
       });
     });
-    
+
     it('should transition from multiple states', function (done) {
       var fsm = StateMachine({
         initial: 'init',
@@ -124,14 +125,28 @@ module.exports = function (promise) {
           } }
         ]
       });
-      
+
       fsm.start().then(function () {
         expect(fsm.current).to.be.equal('b');
-      
+
         done();
       });
     });
-    
+
+    it('should receive the state machine object as the value of "this" ', function (done) {
+      const conditionStub = sinon.stub().returns(1);
+      var fsm = StateMachine({
+        initial: 'init',
+        events: [
+          { name: 'start', from: 'init', to: ['a', 'b'], condition: conditionStub }
+        ],
+      });
+      fsm.start('test').then(function () {
+        expect(conditionStub.thisValues[0]).to.eql(fsm);
+        done();
+      });
+    });
+
     it('should receive original options object', function (done) {
       var fsm = StateMachine({
         initial: 'init',
@@ -165,12 +180,12 @@ module.exports = function (promise) {
           }
         }
       });
-      
+
       fsm.start('test').then(function () {
         done();
       });
     });
-    
+
     it('should receive response set in choice transition callback', function (done) {
       var fsm = StateMachine({
         initial: 'init',
@@ -198,13 +213,13 @@ module.exports = function (promise) {
           }
         }
       });
-      
+
       fsm.start().then(function (result) {
         expect(result).to.be.equal('xyz');
         done();
       });
     });
-    
+
     it('should clear response cache before run', function (done) {
       var fsm = StateMachine({
         initial: 'init',
@@ -222,7 +237,7 @@ module.exports = function (promise) {
           }
         }
       });
-      
+
       fsm.start().then(function (result) {
         expect(result).to.be.equal('start');
         fsm.start().then(function (result) {
@@ -231,7 +246,7 @@ module.exports = function (promise) {
         });
       });
     });
-    
+
     it('should throw error when out of choice index', function (done) {
       var fsm = StateMachine({
         initial: 'init',
@@ -241,14 +256,14 @@ module.exports = function (promise) {
           } }
         ]
       });
-      
+
       fsm.start().catch(function (err) {
         expect(err.message).to.be.equal('Choice index out of range');
         expect(fsm.current).to.be.equal('init');
-      
+
         done();
       });
     });
   });
-  
+
 }


### PR DESCRIPTION
Hi, 

today I noticed that within the condition function the value of "this" corresponds to the event object. Is this the intended behaviour by design? I see that the regular callback handler have the value of "this" corresponding to the state machine object.

See in the pull request that I am binding the invocation to the condition function with "target" as it is done in all the other regular callback invocations.

If you are happy with the modification in behaviour of this pull request I can extend it providing  a unit test for it.