### PR TITLE
Fix error handling for invalid initial state

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -367,7 +367,9 @@ var StateMachine = stampit({
               this.inTransition = false;
               break;
             case Type.NOOP:
-              delete this.states[this.current].noopTransitions[options.id];
+              if (this.states[this.current]) {
+                delete this.states[this.current].noopTransitions[options.id];
+              }
               break;
             default:
           }


### PR DESCRIPTION
Undefined error is thrown when the initial state of the FSM is invalid:

Code sample:
```
var fsm = StateMachine({
   initial: 'invalid',
   events: [
     { name: 'warn',  from: 'green',  to: 'red' },
     { name: 'clear', from: 'yellow', to: 'green'  }
   ]
 });

fsm.warn();
```
